### PR TITLE
Support configurable delimiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This project enables you to:
 - Create easily identifiable spam aliases (e.g. `john.localgym@yourdomain.com` → `john@example.com`).
   - `+` is also a default supported delimiter (like Gmail uses), you can
     configure your own delimiters in the config file. See
-    config/email-config.yml.sample for an example.
+    [config/email-config.yml.sample] for an example.
 - Automate routing logic through a single Cloudflare Worker.
 - Maintain your email forwarding rules via code in a single repository.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ This project enables you to:
 - Define group addresses (e.g. `team@yourdomain.com` → multiple recipients).
 - Create child aliases (e.g. `sally@yourdomain.com` → `sally@example.com`, `parent1@example.com`, and `parent2@example.com`).
 - Create easily identifiable spam aliases (e.g. `john.localgym@yourdomain.com` → `john@example.com`).
-  - `+` is also a supported delimiter (like Gmail uses), and in the future I might support any delimiter through config.
+  - `+` is also a default supported delimiter (like Gmail uses), you can
+    configure your own delimiters in the config file. See
+    config/email-config.yml.sample for an example.
 - Automate routing logic through a single Cloudflare Worker.
 - Maintain your email forwarding rules via code in a single repository.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This project enables you to:
 - Create easily identifiable spam aliases (e.g. `john.localgym@yourdomain.com` → `john@example.com`).
   - `+` is also a default supported delimiter (like Gmail uses), you can
     configure your own delimiters in the config file. See
-    [config/email-config.yml.sample] for an example.
+    [config/email-config.yml.sample](config/email-config.yml.sample) for an example.
 - Automate routing logic through a single Cloudflare Worker.
 - Maintain your email forwarding rules via code in a single repository.
 

--- a/config/email-config.yml.sample
+++ b/config/email-config.yml.sample
@@ -1,5 +1,8 @@
 - domain: my-domain.io
-  config:
+  delimiters:
+    - '.'
+    - '+'
+  accounts:
     - aliases:
         - john
         - jacksr

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -1,4 +1,4 @@
-import type { EmailConfigForDomainType } from "./types";
+import type { AccountsForConfigType } from "./types";
 import { Config } from "./config";
 
 const REJECTION_MESSAGES = {
@@ -9,17 +9,17 @@ const REJECTION_MESSAGES = {
 export class Processor {
   readonly message: any;
   readonly config: Config;
-  readonly configForDomain: EmailConfigForDomainType[] | null;
+  readonly accountsForDomain: AccountsForConfigType[] | null;
 
   constructor(message: any, config: Config) {
     this.message = message;
     this.config = config;
-    this.configForDomain = config.configForDomain;
+    this.accountsForDomain = config.accountsForDomain;
   }
 
   async process(): Promise<void> {
     if (!this.config.isValidRecipient) return this._invalidRejection();
-    if (!this.configForDomain) return this._serverErrorRejection();
+    if (!this.accountsForDomain) return this._serverErrorRejection();
 
     if (this.config.targetFromRecipientWithDelimiter) return this._handleDelimitedTarget();
     if (this.config.recipientConfig) return this._handleSimpleAliasTarget();
@@ -46,7 +46,7 @@ export class Processor {
     if (this.config.targetIsGroup) {
       return await this._forwardEmails(this.config.emailAddressesForGroup(this.config.target!));
     } else {
-      const matchingConfig = this.configForDomain!.find(({ aliases }) =>
+      const matchingConfig = this.accountsForDomain!.find(({ aliases }) =>
         aliases.includes(this.config.target || ""),
       );
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,16 @@
+export interface EmailConfigType {
+  config: EmailConfigForDomainType[];
+  domain: string;
+}
+
 export interface EmailConfigForDomainType {
+  accounts: AccountsForConfigType[];
+  delimiters: string[];
+}
+
+export interface AccountsForConfigType {
   aliases: string[];
   emailAddress: string;
   groups: string[];
   type: string;
-}
-
-export interface EmailConfigType {
-  config: EmailConfigForDomainType[];
-  domain: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,3 @@
-export interface EmailConfigType {
-  config: EmailConfigForDomainType[];
-  domain: string;
-}
-
 export interface EmailConfigForDomainType {
   accounts: AccountsForConfigType[];
   delimiters: string[];

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -14,7 +14,7 @@ describe("Email Worker", () => {
       EMAIL_CONFIG: JSON.stringify([
         {
           domain: "my-domain.com",
-          config: [
+          accounts: [
             {
               aliases: ["one", "anotherone", "thisisanemail", "hello"],
               emailAddress: "sampleparent@email.com",
@@ -31,7 +31,7 @@ describe("Email Worker", () => {
         },
         {
           domain: "myseconddomain.net",
-          config: [
+          accounts: [
             {
               aliases: ["funny", "joke"],
               emailAddress: "serious@jokes.com",
@@ -93,6 +93,35 @@ describe("Email Worker", () => {
     await worker.email(message, env);
 
     expect(message.forward).toHaveBeenCalledWith("sampleparent@email.com");
+    expect(message.setReject).not.toHaveBeenCalled();
+  });
+
+  it("handles alias with delimiter from config correctly", async () => {
+    env.EMAIL_CONFIG = JSON.stringify([
+      {
+        domain: "wow.net",
+        accounts: [
+          {
+            aliases: ["hello"],
+            emailAddress: "my-real-email@example.com",
+          },
+        ],
+        delimiters: [
+          ".",
+          "+",
+          "-",
+        ],
+      },
+    ]);
+    const message = {
+      to: "hello-info@wow.net",
+      setReject: vi.fn(),
+      forward: vi.fn(),
+    };
+
+    await worker.email(message, env);
+
+    expect(message.forward).toHaveBeenCalledWith("my-real-email@example.com");
     expect(message.setReject).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
This PR:
  - Adds support for configurable delimiters in the email config YAML file
  - Updates the documentation
  - Updates the sample config file
  - Updates tests to exercise this new functionality
  - Removes unused type

closes: https://github.com/kenyonj/email-forwarding-worker-template/issues/11